### PR TITLE
fix: add orientation:portrait to iOS splash screen media queries

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,16 +29,16 @@
   <link rel="apple-touch-icon" sizes="1024x1024" href="icons/mealstorm_blue_icon_1024x1024.png">
 
   <!-- iOS Splash Screens -->
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_640x1136.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)">
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_750x1334.png" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)">
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1125x2436.png" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3)">
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1242x2688.png" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_640x1136.png" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_750x1334.png" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1125x2436.png" media="(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1242x2688.png" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
   <!-- iPhone 15 Pro uses 393x852 @3x; iPhone 16 Pro uses 402x874 @3x. -->
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1179x2556.png" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3)">
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1206x2622.png" media="(device-width: 402px) and (device-height: 874px) and (-webkit-device-pixel-ratio: 3)">
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1080x1920.png" media="(device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3)">
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1280x1920.png" media="(device-width: 384px) and (device-height: 576px) and (-webkit-device-pixel-ratio: 2)">
-  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1440x2960.png" media="(device-width: 360px) and (device-height: 740px) and (-webkit-device-pixel-ratio: 3)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1179x2556.png" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1206x2622.png" media="(device-width: 402px) and (device-height: 874px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1080x1920.png" media="(device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1280x1920.png" media="(device-width: 384px) and (device-height: 576px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
+  <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1440x2960.png" media="(device-width: 360px) and (device-height: 740px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)">
   <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1536x2048.png" media="(min-device-width: 768px) and (max-device-width: 1024px)">
   <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_1668x2224.png" media="(min-device-width: 834px) and (max-device-width: 834px)">
   <link rel="apple-touch-startup-image" href="splashscreen/mealstorm_splash_2048x2732.png" media="(min-device-width: 1024px) and (max-device-width: 1024px)">

--- a/tests/mealstorm.spec.js
+++ b/tests/mealstorm.spec.js
@@ -170,7 +170,7 @@ test.describe('Mealstorm regression suite', () => {
 
     const iphone16ProStartupImage = page.locator('link[rel="apple-touch-startup-image"][href="splashscreen/mealstorm_splash_1206x2622.png"]');
     await expect(iphone16ProStartupImage).toHaveCount(1);
-    await expect(iphone16ProStartupImage).toHaveAttribute('media', '(device-width: 402px) and (device-height: 874px) and (-webkit-device-pixel-ratio: 3)');
+    await expect(iphone16ProStartupImage).toHaveAttribute('media', '(device-width: 402px) and (device-height: 874px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)');
 
     await mainTab(page, 'Plan').click();
     await expect(page.getByRole('heading', { name: 'Create a New Meal Plan' })).toBeVisible();


### PR DESCRIPTION
iOS (16.4+) requires orientation to be explicitly declared in apple-touch-startup-image media queries to match correctly. Without it the query is silently skipped — splash never appears on iPhone 16 Pro.